### PR TITLE
Buat tampilan daftar pengguna jetpack compose

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     implementation 'androidx.compose.ui:ui-graphics'
     implementation 'androidx.compose.ui:ui-tooling-preview'
     implementation 'androidx.compose.material3:material3'
+    implementation 'androidx.compose.material:material-icons-extended'
     implementation 'androidx.navigation:navigation-runtime-android:2.9.5'
     implementation "androidx.navigation:navigation-compose:2.9.5"
     testImplementation 'junit:junit:4.13.2'

--- a/app/src/main/java/com/flindigital/watermeter/data/DummyCustomers.kt
+++ b/app/src/main/java/com/flindigital/watermeter/data/DummyCustomers.kt
@@ -1,0 +1,79 @@
+package com.flindigital.watermeter.data
+
+import com.flindigital.watermeter.data.model.Customer
+
+object DummyCustomers {
+    val customers: List<Customer> = listOf(
+        Customer(
+            userId = "081000013690",
+            userName = "Andi Sebastian",
+            date = "Senin, 06 Okt 2025",
+            time = "09:41",
+            fullAddress = "Jl. Kapten Nol, Puruk Cahu",
+            latitude = -1.8701,
+            longitude = 114.9023,
+            isRecorded = false
+        ),
+        Customer(
+            userId = "8723560912",
+            userName = "Rifqi Mufdianto",
+            date = "Senin, 06 Okt 2025",
+            time = "09:45",
+            fullAddress = "Jl. Kapten Nol, Puruk Cahu",
+            latitude = -1.8702,
+            longitude = 114.9026,
+            isRecorded = false
+        ),
+        Customer(
+            userId = "1072833248",
+            userName = "Daffa Kurniawan",
+            date = "Senin, 06 Okt 2025",
+            time = "10:02",
+            fullAddress = "Jl. Kapten Nol, Puruk Cahu",
+            latitude = -1.8704,
+            longitude = 114.9031,
+            isRecorded = false
+        ),
+        Customer(
+            userId = "2346578734",
+            userName = "Chandra Arif",
+            date = "Senin, 06 Okt 2025",
+            time = "10:23",
+            fullAddress = "Jl. Kapten Nol, Puruk Cahu",
+            latitude = -1.8708,
+            longitude = 114.9036,
+            isRecorded = false
+        ),
+        Customer(
+            userId = "2364578689",
+            userName = "Zaky ardiansyah",
+            date = "Senin, 06 Okt 2025",
+            time = "10:31",
+            fullAddress = "Jl. Kapten Nol, Puruk Cahu",
+            latitude = -1.8711,
+            longitude = 114.9040,
+            isRecorded = false
+        ),
+        // already recorded examples
+        Customer(
+            userId = "9911223344",
+            userName = "Siti Rahma",
+            date = "Senin, 06 Okt 2025",
+            time = "08:15",
+            fullAddress = "Jl. Kapten Nol, Puruk Cahu",
+            latitude = -1.8680,
+            longitude = 114.9001,
+            isRecorded = true
+        ),
+        Customer(
+            userId = "7788990011",
+            userName = "Budi Santoso",
+            date = "Senin, 06 Okt 2025",
+            time = "08:32",
+            fullAddress = "Jl. Kapten Nol, Puruk Cahu",
+            latitude = -1.8685,
+            longitude = 114.9009,
+            isRecorded = true
+        )
+    )
+}

--- a/app/src/main/java/com/flindigital/watermeter/data/model/Customer.kt
+++ b/app/src/main/java/com/flindigital/watermeter/data/model/Customer.kt
@@ -1,0 +1,12 @@
+package com.flindigital.watermeter.data.model
+
+data class Customer(
+    val userId: String,
+    val userName: String,
+    val date: String, // e.g., "Senin, 06 Okt 2025"
+    val time: String, // e.g., "09:41"
+    val fullAddress: String,
+    val latitude: Double,
+    val longitude: Double,
+    val isRecorded: Boolean
+)

--- a/app/src/main/java/com/flindigital/watermeter/pages/customers/CustomerListScreen.kt
+++ b/app/src/main/java/com/flindigital/watermeter/pages/customers/CustomerListScreen.kt
@@ -1,0 +1,254 @@
+package com.flindigital.watermeter.pages.customers
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.outlined.LocationOn
+import androidx.compose.material.icons.outlined.Star
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.flindigital.watermeter.data.DummyCustomers
+import com.flindigital.watermeter.data.model.Customer
+
+private val HeaderGreen = Color(0xFF14B8A6)
+private val LightGray = Color(0xFFF1F5F9)
+private val WarningOrange = Color(0xFFFF8A00)
+
+@Composable
+fun CustomerListScreen() {
+    var selectedTab by remember { mutableStateOf(CustomerTab.NotRecorded) }
+    var query by remember { mutableStateOf("") }
+
+    val all = DummyCustomers.customers
+    val filtered = all.filter { c ->
+        (selectedTab == CustomerTab.NotRecorded && !c.isRecorded ||
+                selectedTab == CustomerTab.Recorded && c.isRecorded) &&
+                (c.userName.contains(query, ignoreCase = true) ||
+                        c.userId.contains(query, ignoreCase = true) ||
+                        c.fullAddress.contains(query, ignoreCase = true))
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        HeaderSection(
+            selectedTab = selectedTab,
+            onTabSelected = { selectedTab = it },
+            query = query,
+            onQueryChange = { query = it }
+        )
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(LightGray)
+                .padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            items(filtered) { customer ->
+                CustomerItem(customer = customer, onRecordClick = { /* TODO: integrate navigation */ })
+            }
+        }
+    }
+}
+
+@Composable
+private fun HeaderSection(
+    selectedTab: CustomerTab,
+    onTabSelected: (CustomerTab) -> Unit,
+    query: String,
+    onQueryChange: (String) -> Unit
+) {
+    Surface(color = HeaderGreen) {
+        Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "Daftar Pelanggan",
+                    style = MaterialTheme.typography.titleLarge.copy(
+                        color = Color.White,
+                        fontWeight = FontWeight.SemiBold
+                    ),
+                    modifier = Modifier.weight(1f)
+                )
+                HeaderMonthPill()
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+            SegmentedTabs(selectedTab = selectedTab, onTabSelected = onTabSelected)
+            Spacer(modifier = Modifier.height(12.dp))
+            OutlinedTextField(
+                value = query,
+                onValueChange = onQueryChange,
+                leadingIcon = { Icon(Icons.Filled.Search, contentDescription = null) },
+                placeholder = { Text("Cari…") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(10.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun HeaderMonthPill() {
+    Surface(
+        color = Color(0xFF0EA5A3),
+        contentColor = Color.White,
+        shape = RoundedCornerShape(16.dp)
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(text = "Sept 2025", fontSize = 12.sp)
+            Icon(
+                imageVector = Icons.Filled.ArrowDropDown,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun SegmentedTabs(
+    selectedTab: CustomerTab,
+    onTabSelected: (CustomerTab) -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .background(Color(0xFF0EA5A3)),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Segment(
+            text = "Belum Dicatat",
+            selected = selectedTab == CustomerTab.NotRecorded,
+            onClick = { onTabSelected(CustomerTab.NotRecorded) },
+            modifier = Modifier.weight(1f)
+        )
+        Segment(
+            text = "Sudah Dicatat",
+            selected = selectedTab == CustomerTab.Recorded,
+            onClick = { onTabSelected(CustomerTab.Recorded) },
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+@Composable
+private fun Segment(text: String, selected: Boolean, onClick: () -> Unit, modifier: Modifier = Modifier) {
+    val background = if (selected) Color.White else Color(0xFF0EA5A3)
+    val content = if (selected) Color(0xFF0EA5A3) else Color.White
+    Box(
+        modifier = modifier
+            .background(background)
+            .clickable(onClick = onClick)
+            .padding(vertical = 10.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(text = text, color = content, fontSize = 13.sp, fontWeight = FontWeight.Medium)
+    }
+}
+
+@Composable
+private fun CustomerItem(customer: Customer, onRecordClick: (Customer) -> Unit) {
+    Card(
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        shape = RoundedCornerShape(10.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+    ) {
+        Column(modifier = Modifier.fillMaxWidth().padding(12.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                // Left decorative icon
+                Box(
+                    modifier = Modifier
+                        .size(22.dp)
+                        .clip(CircleShape)
+                        .background(Color(0xFFFFEFD5)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = if (customer.isRecorded) Icons.Outlined.Star else Icons.Outlined.Star,
+                        contentDescription = null,
+                        tint = WarningOrange,
+                        modifier = Modifier.size(16.dp)
+                    )
+                }
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = "ID - ${customer.userId}",
+                    style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+                    modifier = Modifier.weight(1f)
+                )
+                Button(onClick = { onRecordClick(customer) }, shape = RoundedCornerShape(8.dp)) {
+                    Text("Catat")
+                }
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(text = customer.userName, style = MaterialTheme.typography.bodyMedium)
+            Spacer(modifier = Modifier.height(4.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = customer.fullAddress,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color(0xFF70757A),
+                    modifier = Modifier.weight(1f)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Box(
+                    modifier = Modifier
+                        .size(26.dp)
+                        .clip(CircleShape)
+                        .background(Color(0xFFFFF3E7)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.LocationOn,
+                        contentDescription = null,
+                        tint = WarningOrange,
+                        modifier = Modifier.size(18.dp)
+                    )
+                }
+            }
+        }
+    }
+}
+
+private enum class CustomerTab { NotRecorded, Recorded }

--- a/app/src/main/java/com/flindigital/watermeter/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/flindigital/watermeter/ui/navigation/NavGraph.kt
@@ -5,7 +5,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.flindigital.watermeter.pages.detail.DetailScreen
-import com.flindigital.watermeter.pages.home.HomeScreen
+import com.flindigital.watermeter.pages.customers.CustomerListScreen
 
 object Routes {
     const val HOME = "home"
@@ -16,7 +16,7 @@ object Routes {
 fun NavGraph(navController: NavHostController) {
     NavHost(navController = navController, startDestination = Routes.HOME) {
         composable(Routes.HOME) {
-            HomeScreen(onNavigate = { navController.navigate(Routes.DETAIL) })
+            CustomerListScreen()
         }
         composable(Routes.DETAIL) {
             DetailScreen()


### PR DESCRIPTION
Implement a new Jetpack Compose screen to display a list of customer data from dummy sources, including search, segmented filters, and a 'Catat' button per item.

---
<a href="https://cursor.com/background-agent?bcId=bc-d0e08c48-8729-411b-bc37-82bac8ea6e7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d0e08c48-8729-411b-bc37-82bac8ea6e7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

